### PR TITLE
Serialization support for actions returning resources of different types

### DIFF
--- a/lib/ash_ops/task/action.ex
+++ b/lib/ash_ops/task/action.ex
@@ -15,7 +15,7 @@ defmodule AshOps.Task.Action do
          cfg <- Map.put(cfg, :actor, actor),
          {:ok, result} <- run_action(task, cfg),
          {:ok, result} <- maybe_load(result, task, cfg),
-         {:ok, output} <- serialise_result(result, task, cfg) do
+         {:ok, output} <- serialise_result(result, cfg) do
       Mix.shell().info(output)
 
       :ok
@@ -74,12 +74,12 @@ defmodule AshOps.Task.Action do
     end
   end
 
-  defp serialise_result(result, task, cfg) do
+  defp serialise_result(result, cfg) do
     if record_or_records?(result) do
       if is_list(result) do
-        serialise_records(result, task, cfg)
+        serialise_records(result, hd(result).__struct__, cfg)
       else
-        serialise_record(result, task, cfg)
+        serialise_record(result, result.__struct__, cfg)
       end
     else
       serialise_generic_result(result, cfg)

--- a/lib/ash_ops/task/create.ex
+++ b/lib/ash_ops/task/create.ex
@@ -14,7 +14,7 @@ defmodule AshOps.Task.Create do
     with {:ok, cfg} <- ArgSchema.parse(arg_schema, argv),
          {:ok, changeset} <- read_input(task, cfg),
          {:ok, record} <- create_record(changeset, task, cfg),
-         {:ok, output} <- serialise_record(record, task, cfg) do
+         {:ok, output} <- serialise_record(record, task.resource, cfg) do
       Mix.shell().info(output)
       :ok
     else

--- a/lib/ash_ops/task/destroy.ex
+++ b/lib/ash_ops/task/destroy.ex
@@ -28,7 +28,7 @@ defmodule AshOps.Task.Destroy do
       |> Map.put(:domain, task.domain)
       |> Enum.to_list()
 
-    with {:ok, field} <- identity_or_pk_field(task, cfg) do
+    with {:ok, field} <- identity_or_pk_field(task.resource, cfg) do
       task.resource
       |> Query.new()
       |> Query.filter_input(%{field => %{"eq" => cfg.positional_arguments.id}})

--- a/lib/ash_ops/task/get.ex
+++ b/lib/ash_ops/task/get.ex
@@ -16,7 +16,7 @@ defmodule AshOps.Task.Get do
          {:ok, actor} <- load_actor(cfg[:actor], cfg[:tenant]),
          cfg <- Map.put(cfg, :actor, actor),
          {:ok, record} <- load_record(task, cfg),
-         {:ok, output} <- serialise_record(record, task, cfg) do
+         {:ok, output} <- serialise_record(record, task.resource, cfg) do
       Mix.shell().info(output)
 
       :ok
@@ -34,7 +34,7 @@ defmodule AshOps.Task.Get do
       |> Map.put(:authorize_with, :error)
       |> Enum.to_list()
 
-    with {:ok, field} <- identity_or_pk_field(task, cfg) do
+    with {:ok, field} <- identity_or_pk_field(task.resource, cfg) do
       task.resource
       |> Query.new()
       |> Query.for_read(task.action.name)

--- a/lib/ash_ops/task/list.ex
+++ b/lib/ash_ops/task/list.ex
@@ -16,7 +16,7 @@ defmodule AshOps.Task.List do
          {:ok, query} <- QueryLang.parse(task, query),
          {:ok, actor} <- load_actor(cfg[:actor], cfg[:tenant]),
          {:ok, records} <- load_records(query, task, Map.put(cfg, :actor, actor)),
-         {:ok, output} <- serialise_records(records, task, cfg) do
+         {:ok, output} <- serialise_records(records, task.resource, cfg) do
       Mix.shell().info(output)
 
       :ok

--- a/lib/ash_ops/task/update.ex
+++ b/lib/ash_ops/task/update.ex
@@ -17,7 +17,7 @@ defmodule AshOps.Task.Update do
          {:ok, record} <- load_record(task, cfg),
          {:ok, changeset} <- read_input(record, task, cfg),
          {:ok, record} <- update_record(changeset, task, cfg),
-         {:ok, output} <- serialise_record(record, task, cfg) do
+         {:ok, output} <- serialise_record(record, task.resource, cfg) do
       Mix.shell().info(output)
       :ok
     else
@@ -44,7 +44,7 @@ defmodule AshOps.Task.Update do
       |> Map.put(:authorize_with, :error)
       |> Enum.to_list()
 
-    with {:ok, field} <- identity_or_pk_field(task, cfg) do
+    with {:ok, field} <- identity_or_pk_field(task.resource, cfg) do
       task.resource
       |> Query.new()
       |> Query.for_read(task.read_action.name)


### PR DESCRIPTION
Generic actions returning Ash resources of a different type to the resource that contains the action are now serialised correctly.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring



---

Some test cases from my own project:


### Returning a single resource
```sh
mix realworld.accounts.generate_user 1

id: 39adb19f-7636-4531-883b-dd1e22cb8468
image: /images/avatar.png
username: samanta2031
bio: nil
email: andy.braun@hagenes.com
```

### Returning a list of Article with associated User (belongs_to) and Tags (many_to_many) in YAML format

```
mix realworld.articles.generate_article 2 --actor Realworld.Accounts.User:39adb19f-7636-4531-883b-dd1e22cb8468
id: 746a3c5b-e2a9-412e-b4ca-6dda437e849a
user:
  id: 39adb19f-7636-4531-883b-dd1e22cb8468
  image: /images/avatar.png
  username: samanta2031
  bio: nil
  email: andy.braun@hagenes.com
description: Numquam nemo dolorem nisi maxime.
title: Voluptatem ea officia nemo?
body: |-
  <p>
  Occaecati voluptas qui et qui maxime ut. Fuga ipsum adipisci tenetur deserunt.</p>
  <p>
  Voluptatibus autem itaque culpa ut. Rerum laborum dolorum voluptatum nisi ut aut aut quam sit!</p>
  <p>
  Expedita est sint repudiandae. Ipsum dolores vitae unde aut molestias id hic veritatis. Sit voluptatem laboriosam in aliquam facere qui doloremque sed fugiat.</p>
tags:
  - id: 8d84962a-27c7-4679-9d60-61a8ef50696d
    name: laborum
  - id: f8d1b44f-c041-4f73-8fc3-dd356a5e7aaf
    name: et
  - id: 76d28877-925c-4b9e-b332-747a3a739b97
    name: eligendi
created_at:
  2025-04-23T06:58:43.791734Z
body_raw: |-
  Occaecati voluptas qui et qui maxime ut. Fuga ipsum adipisci tenetur deserunt.

  Voluptatibus autem itaque culpa ut. Rerum laborum dolorum voluptatum nisi ut aut aut quam sit!

  Expedita est sint repudiandae. Ipsum dolores vitae unde aut molestias id hic veritatis. Sit voluptatem laboriosam in aliquam facere qui doloremque sed fugiat.
slug: voluptatem-ea-officia-nemo
user_id: 39adb19f-7636-4531-883b-dd1e22cb8468
---
id: da45d974-4085-452f-9873-e77a1542649d
user:
  id: 39adb19f-7636-4531-883b-dd1e22cb8468
  image: /images/avatar.png
  username: samanta2031
  bio: nil
  email: andy.braun@hagenes.com
description: Facilis magni consectetur ratione voluptas ipsum qui et.
title: Nemo dolorem perferendis.
body: |-
  <p>
  Magnam quo illum tempora suscipit ipsam officia ea deleniti laborum! Laboriosam animi autem animi culpa quisquam ea eum? Animi impedit accusamus ex aut. Quis aspernatur ea ab possimus mollitia et sed et.</p>
  <p>
  Dolore laboriosam vero ipsa. Excepturi commodi odit sit quam ut corrupti voluptatem! Sed aut aperiam vero vel quaerat distinctio odio.</p>
  <p>
  Quod unde officiis est tempore corrupti voluptatum. Sed tenetur officiis dicta voluptatum consequatur. Atque quia molestias veniam et quo delectus tempora nesciunt.</p>
  <p>
  In labore ea tempora. Nobis velit repellendus voluptatem voluptatem!</p>
tags:
  - id: a187285e-f7d3-4d83-8071-fd4bada570d6
    name: rem
  - id: 9b691134-7e82-4911-9837-e54a6d0f4d6f
    name: sit
  - id: 80a7ff50-e375-42e2-8ec8-21cbf51e40b8
    name: molestiae
created_at:
  2025-04-23T06:58:43.791734Z
body_raw: |-
  Magnam quo illum tempora suscipit ipsam officia ea deleniti laborum! Laboriosam animi autem animi culpa quisquam ea eum? Animi impedit accusamus ex aut. Quis aspernatur ea ab possimus mollitia et sed et.

  Dolore laboriosam vero ipsa. Excepturi commodi odit sit quam ut corrupti voluptatem! Sed aut aperiam vero vel quaerat distinctio odio.

  Quod unde officiis est tempore corrupti voluptatum. Sed tenetur officiis dicta voluptatum consequatur. Atque quia molestias veniam et quo delectus tempora nesciunt.

  In labore ea tempora. Nobis velit repellendus voluptatem voluptatem!
slug: nemo-dolorem-perferendis
user_id: 39adb19f-7636-4531-883b-dd1e22cb8468
```


### Returning a list of Article with associated User (belongs_to) and Tags (many_to_many) in YAML format

```
 mix realworld.articles.generate_article 2 --actor Realworld.Accounts.User:39adb19f-7636-4531-883b-dd1e22cb8468 --format=json

[
  {
    "id": "222d7950-f45f-4536-8a25-78690e6a7800",
    "user": {
      "id": "39adb19f-7636-4531-883b-dd1e22cb8468",
      "image": "/images/avatar.png",
      "username": "samanta2031",
      "bio": null,
      "email": "andy.braun@hagenes.com"
    },
    "description": "Esse labore quia corporis. Sapiente voluptas totam assumenda doloremque explicabo animi.",
    "title": "Corrupti in voluptatem.",
    "body": "<p>\nCulpa quia ea non non non eum ipsam in. Non explicabo libero architecto nesciunt corporis amet. Nobis voluptates consequatur dolor sapiente autem praesentium velit. Pariatur id praesentium unde placeat! Nam voluptatem sunt sapiente vel?</p>\n<p>\nCum sit saepe illum numquam facilis distinctio qui qui sint? Vitae adipisci molestias qui temporibus tenetur non in? Quia perspiciatis provident natus aut dolores qui quibusdam deleniti! Odit quibusdam sunt hic sed rerum laudantium quisquam? Magni aut dolorem consequatur.</p>\n<p>\nAccusantium quibusdam eligendi expedita ut amet asperiores? Id in quisquam velit itaque qui architecto! Ut quia et sint quasi eos eius?</p>\n<p>\nEt et aut velit quia sed? Voluptatem eos enim adipisci.</p>\n<p>\nEa atque omnis excepturi. Omnis adipisci non ullam deserunt laborum.</p>",
    "tags": [
      {
        "id": "f8d1b44f-c041-4f73-8fc3-dd356a5e7aaf",
        "name": "et"
      },
      {
        "id": "6341651a-bf2e-4b65-9228-ad3f641ff816",
        "name": "placeat"
      }
    ],
    "created_at": "2025-04-23T07:00:19.961392Z",
    "body_raw": "Culpa quia ea non non non eum ipsam in. Non explicabo libero architecto nesciunt corporis amet. Nobis voluptates consequatur dolor sapiente autem praesentium velit. Pariatur id praesentium unde placeat! Nam voluptatem sunt sapiente vel?\n\nCum sit saepe illum numquam facilis distinctio qui qui sint? Vitae adipisci molestias qui temporibus tenetur non in? Quia perspiciatis provident natus aut dolores qui quibusdam deleniti! Odit quibusdam sunt hic sed rerum laudantium quisquam? Magni aut dolorem consequatur.\n\nAccusantium quibusdam eligendi expedita ut amet asperiores? Id in quisquam velit itaque qui architecto! Ut quia et sint quasi eos eius?\n\nEt et aut velit quia sed? Voluptatem eos enim adipisci.\n\nEa atque omnis excepturi. Omnis adipisci non ullam deserunt laborum.",
    "slug": "corrupti-in-voluptatem",
    "user_id": "39adb19f-7636-4531-883b-dd1e22cb8468"
  },
  {
    "id": "1cbb6f34-d3e2-4d3b-8a12-75e59ce87016",
    "user": {
      "id": "39adb19f-7636-4531-883b-dd1e22cb8468",
      "image": "/images/avatar.png",
      "username": "samanta2031",
      "bio": null,
      "email": "andy.braun@hagenes.com"
    },
    "description": "Nemo et et fuga error.",
    "title": "Reprehenderit ut optio repudiandae pariatur!",
    "body": "<p>\nBeatae iure quia earum nemo illo totam molestiae odio? Dolorum ipsa omnis similique dolorum perspiciatis molestiae aut enim omnis! Eveniet voluptatem delectus facere id rerum tenetur pariatur iusto laborum.</p>\n<p>\nVoluptatum fugit ut ad explicabo qui aut. Qui quod sit eaque voluptatem in! Corrupti dolorem architecto occaecati expedita quia adipisci assumenda. Qui beatae non at explicabo alias amet neque? Accusantium nulla id molestias dolore.</p>\n<p>\nId voluptates odio consequatur voluptas veniam quibusdam sit necessitatibus officiis! Aut placeat repellendus quo voluptatem consequatur ut accusamus non. Amet esse est et harum deleniti?</p>\n<p>\nModi repellat velit et et illo consequatur aliquid. Sed nihil et autem.</p>",
    "tags": [
      {
        "id": "6f689579-dc0a-422b-9d54-2a1cc5a36a64",
        "name": "ratione"
      },
      {
        "id": "4dc08184-15df-437b-88d1-2428dad59787",
        "name": "quis"
      },
      {
        "id": "a82a31ce-9201-455e-9b02-bd9ff1e9f71f",
        "name": "ut"
      }
    ],
    "created_at": "2025-04-23T07:00:19.961392Z",
    "body_raw": "Beatae iure quia earum nemo illo totam molestiae odio? Dolorum ipsa omnis similique dolorum perspiciatis molestiae aut enim omnis! Eveniet voluptatem delectus facere id rerum tenetur pariatur iusto laborum.\n\nVoluptatum fugit ut ad explicabo qui aut. Qui quod sit eaque voluptatem in! Corrupti dolorem architecto occaecati expedita quia adipisci assumenda. Qui beatae non at explicabo alias amet neque? Accusantium nulla id molestias dolore.\n\nId voluptates odio consequatur voluptas veniam quibusdam sit necessitatibus officiis! Aut placeat repellendus quo voluptatem consequatur ut accusamus non. Amet esse est et harum deleniti?\n\nModi repellat velit et et illo consequatur aliquid. Sed nihil et autem.",
    "slug": "reprehenderit-ut-optio-repudiandae-pariatur",
    "user_id": "39adb19f-7636-4531-883b-dd1e22cb8468"
  }
]
```